### PR TITLE
Add Fragments.in with 3 parameters

### DIFF
--- a/modules/core/src/main/scala/doobie/util/fragments.scala
+++ b/modules/core/src/main/scala/doobie/util/fragments.scala
@@ -24,6 +24,10 @@ object fragments {
   def in[F[_]: Reducible, A: util.Put, B: util.Put](f: Fragment, fs: F[(A,B)]): Fragment =
     fs.toList.map { case (a,b) => fr0"($a,$b)" }.foldSmash1(f ++ fr0"IN (", fr",", fr")")
 
+  /** Returns `f IN ((fs0-A, fs0-B, fs0-C), (fs1-A, fs1-B, fs1-C), ...)`. */
+  def in[F[_]: Reducible, A: util.Put, B: util.Put, C: util.Put](f: Fragment, fs: F[(A,B,C)]): Fragment =
+    fs.toList.map { case (a,b,c) => fr0"($a,$b,$c)" }.foldSmash1(f ++ fr0"IN (", fr",", fr")")
+
   /** Returns `f NOT IN (fs0, fs1, ...)`. */
   def notIn[F[_]: Reducible, A: util.Put](f: Fragment, fs: F[A]): Fragment =
     fs.toList.map(a => fr0"$a").foldSmash1(f ++ fr0"NOT IN (", fr",", fr")")

--- a/modules/core/src/test/scala/doobie/util/FragmentsSuite.scala
+++ b/modules/core/src/test/scala/doobie/util/FragmentsSuite.scala
@@ -40,6 +40,10 @@ class FragmentsSuite extends munit.FunSuite {
     assertEquals(in(fr"foo", NonEmptyList.of((1, true), (2, false))).query[Unit].sql, "foo IN ((?,?), (?,?)) ")
   }
 
+  test("in for three columns") {
+    assertEquals(in(fr"foo", NonEmptyList.of((1, true, 3), (2, false, 4))).query[Unit].sql, "foo IN ((?,?,?), (?,?,?)) ")
+  }
+
   test("notIn") {
     assertEquals(notIn(fr"foo", nel).query[Unit].sql, "foo NOT IN (?, ?, ?) ")
   }


### PR DESCRIPTION
This PR adds a `Fragments.in` variant for tuples of three elements. Hence, we can now do something like this:

```
WHERE (col1, col2, col3) IN ((1,2,3), (2,3,4))
```