### PR TITLE
Introduces attemptSomeSql into ApplicativeErrorOps

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,7 @@ services:
 
 
   mysql:
-    image: mysql:8.0-debian
+    image: mysql:8.0
     environment:
       MYSQL_ROOT_PASSWORD: password
       MYSQL_DATABASE: world

--- a/modules/core/src/main/scala/doobie/syntax/applicativeerror.scala
+++ b/modules/core/src/main/scala/doobie/syntax/applicativeerror.scala
@@ -11,6 +11,7 @@ import java.sql.SQLException
 
 class ApplicativeErrorOps[M[_], A](self: M[A])(implicit ev: ApplicativeError[M, Throwable]) {
   def attemptSql: M[Either[SQLException, A]] = C.attemptSql(self)
+  def attemptSomeSql[B](f: PartialFunction[SQLException, B]): M[Either[B, A]] = C.attemptSomeSql(self)(f)
   def attemptSqlState: M[Either[SqlState, A]] = C.attemptSqlState(self)
   def attemptSomeSqlState[B](f: PartialFunction[SqlState, B]): M[Either[B, A]] = C.attemptSomeSqlState(self)(f)
   def exceptSql(handler: SQLException => M[A]): M[A] = C.exceptSql(self)(handler)


### PR DESCRIPTION
Introduces an `attemptSomeSql` catcher to partial match on a specific `SQLException`.
The use case for it is to match both the stage, but also log the exception itself:

```scala
        .attemptSomeSql {
          case e: PSQLException if SqlState(e.getSQLState) == sqlstate.class23.UNIQUE_VIOLATION =>
            logger.error("Database Unique Violation", e)
            DbCreateError.UniqueViolation
          case e: PSQLException if SqlState(e.getSQLState) == sqlstate.class23.CHECK_VIOLATION  =>
            logger.error("Database Check Violation", e)
            DbCreateError.CheckViolationOnCreate
        }

```

For some reason `attemptSomeSql` catcher is mentioned in the docs but not implemented.

Also, I've changed the docker-compose mysql image to not rely on the debian version, as that's not available for arm64 devs