### PR TITLE
Update microsite link

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 **doobie** is a pure functional JDBC layer for Scala.
 
-Please proceed to the [**microsite**](https://tpolecat.github.io/doobie/) for more information.
+Please proceed to the [**microsite**](https://typelevel.org/doobie/) for more information.
 
 ## Reporting a bug or need help?
 

--- a/modules/docs/src/main/mdoc/docs/12-Custom-Mappings.md
+++ b/modules/docs/src/main/mdoc/docs/12-Custom-Mappings.md
@@ -56,7 +56,7 @@ Instances are provided for the following Scala types:
 - `Instant`, `LocalDate`, `LocalTime`, `LocalDateTime`, `OffsetTime` and `OffsetDateTime` from the `java.time` package; and
 - single-element case classes wrapping one of the above types.
 
-The `java.time` instances may require a separate import , dependent on your Database Driver . See the [doobie-faq](https://tpolecat.github.io/doobie/docs/17-FAQ.html#how-do-i-use-java-time-types-with-doobie-) for details
+The `java.time` instances may require a separate import , dependent on your Database Driver . See the [doobie-faq](https://typelevel.org/doobie/docs/17-FAQ.html#how-do-i-use-java-time-types-with-doobie-) for details
 
 The above cases are defined by the JDBC specification. See later chapters on vendor-specific additions, which provide mappings for some non-standard types such as `UUID`s and network addresses.
 

--- a/modules/hikari/src/main/scala/doobie/hikari/HikariTransactor.scala
+++ b/modules/hikari/src/main/scala/doobie/hikari/HikariTransactor.scala
@@ -240,7 +240,7 @@ object HikariTransactor {
       // Note that the number of JDBC connections is usually limited by the underlying JDBC pool.
       // You may therefore want to limit your connection pool to the same size as the underlying JDBC pool
       // as any additional threads are guaranteed to be blocked.
-      // https://tpolecat.github.io/doobie/docs/14-Managing-Connections.html#about-threading
+      // https://typelevel.org/doobie/docs/14-Managing-Connections.html#about-threading
       connectEC <- ExecutionContexts.fixedThreadPool[M0](hikariConfig.getMaximumPoolSize)
       result <- fromHikariConfigCustomEcWithResEffect[M0, M](hikariConfig, connectEC, logHandler)
     } yield result


### PR DESCRIPTION
I noticed that links in the README.md stopped working. Once I saw the discussion about moving the repository into the typelevel org, I figured out why. I replaced the old link with `https://typelevel.org/doobie/`. Since it would be more annoying to open an issue than it was to fix this, I created this PR straight away. If this is not okay then feel free to ignore it and sorry for the trouble.