### PR TITLE
Introduce `updateSetOpt` fragment (#1893)

### DIFF
--- a/modules/core/src/main/scala/doobie/util/fragments.scala
+++ b/modules/core/src/main/scala/doobie/util/fragments.scala
@@ -25,7 +25,8 @@ object fragments {
       condition: Fragment
   ): Option[Fragment] = {
     NonEmptyList.fromFoldable(columnUpdates).map(cs =>
-      fr"UPDATE" ++ tableName ++ set(cs) ++ (if (condition == Fragment.empty) condition else fr"" ++ whereAnd(condition)))
+      fr"UPDATE" ++ tableName ++ set(cs) ++ (if (condition == Fragment.empty) condition
+                                             else fr"" ++ whereAnd(condition)))
   }
 
   /** Returns `(f IN (fs0, fs1, ...))`. */

--- a/modules/core/src/main/scala/doobie/util/fragments.scala
+++ b/modules/core/src/main/scala/doobie/util/fragments.scala
@@ -18,15 +18,12 @@ object fragments {
   def values[F[_]: Reducible, A](fs: F[A])(implicit w: util.Write[A]): Fragment =
     fr"VALUES" ++ comma(fs.toNonEmptyList.map(f => parentheses(values(f))))
 
-  /** Returns `UPDATE tableName SET columnUpdate0, columnUpdate1, ... WHERE (whereAnd0) AND (whereAnd1) ...`. */
+  /** Returns `UPDATE tableName SET columnUpdate0, columnUpdate1, ...`. */
   def updateSetOpt[F[_]: Foldable](
       tableName: Fragment,
-      columnUpdates: F[Fragment],
-      condition: Fragment
+      columnUpdates: F[Fragment]
   ): Option[Fragment] = {
-    NonEmptyList.fromFoldable(columnUpdates).map(cs =>
-      fr"UPDATE" ++ tableName ++ set(cs) ++ (if (condition == Fragment.empty) condition
-                                             else fr"" ++ whereAnd(condition)))
+    NonEmptyList.fromFoldable(columnUpdates).map(cs => fr"UPDATE" ++ tableName ++ set(cs))
   }
 
   /** Returns `(f IN (fs0, fs1, ...))`. */

--- a/modules/core/src/main/scala/doobie/util/fragments.scala
+++ b/modules/core/src/main/scala/doobie/util/fragments.scala
@@ -22,10 +22,10 @@ object fragments {
   def updateSetOpt[F[_]: Foldable](
       tableName: Fragment,
       columnUpdates: F[Fragment],
-      whereAnd: F[Fragment]
+      condition: Fragment
   ): Option[Fragment] = {
     NonEmptyList.fromFoldable(columnUpdates).map(cs =>
-      fr"UPDATE" ++ tableName ++ set(cs) ++ fr"" ++ whereAndOpt(whereAnd))
+      fr"UPDATE" ++ tableName ++ set(cs) ++ (if (condition == Fragment.empty) condition else fr"" ++ whereAnd(condition)))
   }
 
   /** Returns `(f IN (fs0, fs1, ...))`. */

--- a/modules/core/src/test/scala/doobie/util/FragmentsSuite.scala
+++ b/modules/core/src/test/scala/doobie/util/FragmentsSuite.scala
@@ -40,25 +40,25 @@ class FragmentsSuite extends munit.FunSuite {
 
   test("updateSetOpt for three column") {
     assertEquals(
-      updateSetOpt(Fragment.const("Foo"), sqlKv, List.empty[Fragment]).map(_.query[Unit].sql),
-      Some("UPDATE Foo SET a = ?, b = ?, c = ? "))
+      updateSetOpt(Fragment.const("Foo"), sqlKv, Fragment.empty).map(_.query[Unit].sql),
+      Some("UPDATE Foo SET a = ?, b = ?, c = ?"))
   }
 
   test("updateSetOpt for empty columns") {
     assertEquals(
-      updateSetOpt(Fragment.const("Foo"), List.empty[Fragment], List.empty[Fragment]).map(_.query[Unit].sql),
+      updateSetOpt(Fragment.const("Foo"), List.empty[Fragment], Fragment.empty).map(_.query[Unit].sql),
       None)
   }
 
   test("updateSetOpt for three column and defined where clause") {
     assertEquals(
-      updateSetOpt(Fragment.const("Foo"), sqlKv, List(fr0"id = 1")).map(_.query[Unit].sql),
+      updateSetOpt(Fragment.const("Foo"), sqlKv, fr0"id = 1").map(_.query[Unit].sql),
       Some("UPDATE Foo SET a = ?, b = ?, c = ? WHERE (id = 1)"))
   }
 
   test("updateSetOpt for empty columns but defined where clause") {
     assertEquals(
-      updateSetOpt(Fragment.const("Foo"), List.empty[Fragment], List(fr0"id = 1")).map(_.query[Unit].sql),
+      updateSetOpt(Fragment.const("Foo"), List.empty[Fragment], fr0"id = 1").map(_.query[Unit].sql),
       None)
   }
 

--- a/modules/core/src/test/scala/doobie/util/FragmentsSuite.scala
+++ b/modules/core/src/test/scala/doobie/util/FragmentsSuite.scala
@@ -40,26 +40,12 @@ class FragmentsSuite extends munit.FunSuite {
 
   test("updateSetOpt for three column") {
     assertEquals(
-      updateSetOpt(Fragment.const("Foo"), sqlKv, Fragment.empty).map(_.query[Unit].sql),
+      updateSetOpt(Fragment.const("Foo"), sqlKv).map(_.query[Unit].sql),
       Some("UPDATE Foo SET a = ?, b = ?, c = ?"))
   }
 
   test("updateSetOpt for empty columns") {
-    assertEquals(
-      updateSetOpt(Fragment.const("Foo"), List.empty[Fragment], Fragment.empty).map(_.query[Unit].sql),
-      None)
-  }
-
-  test("updateSetOpt for three column and defined where clause") {
-    assertEquals(
-      updateSetOpt(Fragment.const("Foo"), sqlKv, fr0"id = 1").map(_.query[Unit].sql),
-      Some("UPDATE Foo SET a = ?, b = ?, c = ? WHERE (id = 1)"))
-  }
-
-  test("updateSetOpt for empty columns but defined where clause") {
-    assertEquals(
-      updateSetOpt(Fragment.const("Foo"), List.empty[Fragment], fr0"id = 1").map(_.query[Unit].sql),
-      None)
+    assertEquals(updateSetOpt(Fragment.const("Foo"), List.empty[Fragment]).map(_.query[Unit].sql), None)
   }
 
   test("in (1-column varargs)") {


### PR DESCRIPTION
This tries to solve #1893.

I hope the tests run through, as I could not successfully run all tests locally. At some point the testsuite just hanged on my Apple M1. Also, locally, I needed to switch the mysql docker image in the docker compose file to work on the M1.

