### PR TITLE
Fix dead link to the 'Preserving Time Instants' article

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -41,7 +41,6 @@ ThisBuild / crossScalaVersions := Seq(scala212Version, scala213Version, scala3Ve
 ThisBuild / developers += tlGitHubDev("tpolecat", "Rob Norris")
 ThisBuild / tpolecatDefaultOptionsMode :=
   (if (sys.env.contains("CI")) CiMode else DevMode)
-ThisBuild / tlSonatypeUseLegacyHost := false
 ThisBuild / githubWorkflowJavaVersions := Seq(JavaSpec.temurin("11"))
 ThisBuild / githubWorkflowBuildPreamble ++= Seq(
   WorkflowStep.Run(

--- a/modules/mysql/src/main/scala/doobie/mysql/MysqlJavaTimeInstances.scala
+++ b/modules/mysql/src/main/scala/doobie/mysql/MysqlJavaTimeInstances.scala
@@ -18,7 +18,7 @@ import java.time.ZoneOffset
 /** Instances for JSR-310 date time types.
   *
   * Note that to ensure instants are preserved you may need to use one of the solutions described in
-  * [[https://docs.oracle.com/cd/E17952_01/connector-j-8.0-en/connector-j-time-instants.html]].
+  * [[https://docs.oracle.com/cd/E17952_01/connector-j-en/connector-j-time-instants.html]].
   *
   * OffsetTime instance is not supported as there is no semantically equivalent type on the MySQL side.
   */

--- a/modules/mysql/src/test/scala/doobie/mysql/MySQLTestTransactor.scala
+++ b/modules/mysql/src/test/scala/doobie/mysql/MySQLTestTransactor.scala
@@ -11,7 +11,7 @@ object MySQLTestTransactor {
 
   val xa = Transactor.fromDriverManager[IO](
     "com.mysql.cj.jdbc.Driver",
-    // args from solution 2a https://docs.oracle.com/cd/E17952_01/connector-j-8.0-en/connector-j-time-instants.html
+    // args from solution 2a https://docs.oracle.com/cd/E17952_01/connector-j-en/connector-j-time-instants.html
     "jdbc:mysql://localhost:3306/world?preserveInstants=true&connectionTimeZone=SERVER",
     "root",
     "password",


### PR DESCRIPTION
This includes several minor fixes: fixing dead links to the article on the Oracle docs site and resolving a warning in the SBT shell.