### PR TITLE
Simplify Config (public constructor, etc)

### DIFF
--- a/modules/hikari/src/main/scala/doobie/hikari/Config.scala
+++ b/modules/hikari/src/main/scala/doobie/hikari/Config.scala
@@ -20,15 +20,8 @@ import scala.concurrent.duration.Duration
 /** Configuration case class, susceptible to PureConfig. Helps with creating `com.zaxxer.hikari.HikariConfig`, which in
   * turn is used to create `doobie.hikari.HikariTransactor`. See the method `HikariTransactor.fromConfigAutoEc`
   */
-// Whenever you add a new field to maintain backward compatibility:
-//  * add the field to `copy`
-//  * create a new `apply`
-//  * add a new case to `fromProduct`
-//
-// The default values in the constructor are not actually applied (defaults from `apply` are).
-// But they still need to be present to enable tools like PureConfig.
-@nowarn("msg=(never used|unused)")
-final case class Config private (
+// When you add a new field to maintain backward compatibility, use https://github.com/com-lihaoyi/unroll
+final case class Config(
     jdbcUrl: String,
     catalog: Option[String] = None,
     connectionTimeout: Duration = Duration(30, TimeUnit.SECONDS),
@@ -54,36 +47,7 @@ final case class Config private (
     registerMbeans: Boolean = false,
     schema: Option[String] = None,
     transactionIsolation: Option[TransactionIsolation] = None
-) {
-  @nowarn("msg=(never used|unused)")
-  private def copy(
-      jdbcUrl: String,
-      catalog: Option[String],
-      connectionTimeout: Duration,
-      idleTimeout: Duration,
-      leakDetectionThreshold: Duration,
-      maximumPoolSize: Int,
-      maxLifetime: Duration,
-      minimumIdle: Int,
-      password: Option[String],
-      poolName: Option[String],
-      username: Option[String],
-      validationTimeout: Duration,
-      allowPoolSuspension: Boolean,
-      autoCommit: Boolean,
-      connectionInitSql: Option[String],
-      connectionTestQuery: Option[String],
-      dataSourceClassName: Option[String],
-      dataSourceJNDI: Option[String],
-      driverClassName: Option[String],
-      initializationFailTimeout: Duration,
-      isolateInternalQueries: Boolean,
-      readOnly: Boolean,
-      registerMbeans: Boolean,
-      schema: Option[String],
-      transactionIsolation: Option[TransactionIsolation]
-  ): Any = this
-}
+)
 
 object Config {
   def makeHikariConfig[F[_]](
@@ -139,92 +103,4 @@ object Config {
 
       c
     }
-
-  def apply(
-      jdbcUrl: String,
-      catalog: Option[String] = None,
-      connectionTimeout: Duration = Duration(30, TimeUnit.SECONDS),
-      idleTimeout: Duration = Duration(10, TimeUnit.MINUTES),
-      leakDetectionThreshold: Duration = Duration.Zero,
-      maximumPoolSize: Int = 10,
-      maxLifetime: Duration = Duration(30, TimeUnit.MINUTES),
-      minimumIdle: Int = 10,
-      password: Option[String] = None,
-      poolName: Option[String] = None,
-      username: Option[String] = None,
-      validationTimeout: Duration = Duration(5, TimeUnit.SECONDS),
-      allowPoolSuspension: Boolean = false,
-      autoCommit: Boolean = true,
-      connectionInitSql: Option[String] = None,
-      connectionTestQuery: Option[String] = None,
-      dataSourceClassName: Option[String] = None,
-      dataSourceJNDI: Option[String] = None,
-      driverClassName: Option[String] = None,
-      initializationFailTimeout: Duration = Duration(1, TimeUnit.MILLISECONDS),
-      isolateInternalQueries: Boolean = false,
-      readOnly: Boolean = false,
-      registerMbeans: Boolean = false,
-      schema: Option[String] = None,
-      transactionIsolation: Option[TransactionIsolation] = None
-  ): Config = new Config(
-    jdbcUrl = jdbcUrl,
-    catalog = catalog,
-    connectionTimeout = connectionTimeout,
-    idleTimeout = idleTimeout,
-    leakDetectionThreshold = leakDetectionThreshold,
-    maximumPoolSize = maximumPoolSize,
-    maxLifetime = maxLifetime,
-    minimumIdle = minimumIdle,
-    password = password,
-    poolName = poolName,
-    username = username,
-    validationTimeout = validationTimeout,
-    allowPoolSuspension = allowPoolSuspension,
-    autoCommit = autoCommit,
-    connectionInitSql = connectionInitSql,
-    connectionTestQuery = connectionTestQuery,
-    dataSourceClassName = dataSourceClassName,
-    dataSourceJNDI = dataSourceJNDI,
-    driverClassName = driverClassName,
-    initializationFailTimeout = initializationFailTimeout,
-    isolateInternalQueries = isolateInternalQueries,
-    readOnly = readOnly,
-    registerMbeans = registerMbeans,
-    schema = schema,
-    transactionIsolation = transactionIsolation
-  )
-
-  def fromProduct(p: Product): Config = p.productArity match {
-    case 25 =>
-      Config(
-        p.productElement(0).asInstanceOf[String],
-        p.productElement(1).asInstanceOf[Option[String]],
-        p.productElement(2).asInstanceOf[Duration],
-        p.productElement(3).asInstanceOf[Duration],
-        p.productElement(4).asInstanceOf[Duration],
-        p.productElement(5).asInstanceOf[Int],
-        p.productElement(6).asInstanceOf[Duration],
-        p.productElement(7).asInstanceOf[Int],
-        p.productElement(8).asInstanceOf[Option[String]],
-        p.productElement(9).asInstanceOf[Option[String]],
-        p.productElement(10).asInstanceOf[Option[String]],
-        p.productElement(11).asInstanceOf[Duration],
-        p.productElement(12).asInstanceOf[Boolean],
-        p.productElement(13).asInstanceOf[Boolean],
-        p.productElement(14).asInstanceOf[Option[String]],
-        p.productElement(15).asInstanceOf[Option[String]],
-        p.productElement(16).asInstanceOf[Option[String]],
-        p.productElement(17).asInstanceOf[Option[String]],
-        p.productElement(18).asInstanceOf[Option[String]],
-        p.productElement(19).asInstanceOf[Duration],
-        p.productElement(20).asInstanceOf[Boolean],
-        p.productElement(21).asInstanceOf[Boolean],
-        p.productElement(22).asInstanceOf[Boolean],
-        p.productElement(23).asInstanceOf[Option[String]],
-        p.productElement(24).asInstanceOf[Option[TransactionIsolation]]
-      )
-  }
-
-  @nowarn("msg=(never used|unused)")
-  private def unapply(c: Config): Any = this
 }


### PR DESCRIPTION
We can rely on unroll (instead of doing it manually) when we need to add more fields.

This is also a required change to enable derivation via PureConfig or Magnolia.